### PR TITLE
Add requirements.txt for generate_side_by_side.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+certifi==2020.12.5
+chardet==4.0.0
+cycler==0.10.0
+idna==2.10
+kiwisolver==1.3.1
+matplotlib==3.4.1
+numpy==1.20.2
+opencv-python==4.5.1.48
+Pillow==8.2.0
+pyparsing==2.4.7
+python-dateutil==2.8.1
+requests==2.25.1
+scipy==1.6.2
+six==1.15.0
+urllib3==1.26.4


### PR DESCRIPTION
I needed to install a number of things before generate_side_by_side.py would show its `--help`. This requirements.txt is what I got from running `pip3 freeze > requirements.txt`.