### PR TITLE
Bug 2033807 - Pin numpy to 1.23.5 for Python >= 3.8 to ensure wheel a…

### DIFF
--- a/mozperftest_tools/setup.py
+++ b/mozperftest_tools/setup.py
@@ -17,7 +17,7 @@ deps = [
     "numpy<1.21; python_version<='3.7'",
     "scipy<1.8; python_version<='3.7'",
     "opencv-python==4.8.1.78; python_version>='3.8'",
-    "numpy>=1.23.5; python_version>='3.8'",
+    "numpy==1.23.5; python_version>='3.8'",
     "scipy==1.10.0; python_version>='3.8'",
 ]
 


### PR DESCRIPTION
Pin numpy to 1.23.5 for Python >= 3.8 to ensure wheel availability on internal mirror